### PR TITLE
Deprecatated --migrate in README and whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Speakerfight is an arena where the Speakers can fight each other and the people 
 $ git clone git@github.com:luanfonceca/speakerfight.git
 $ cd speakerfight
 $ sudo pip install -r requirements.txt
-$ python manage.py syncdb --migrate # we have a fixture for the users...
-$ python manage.py loaddata deck/fixtures/user.json 
-# username: admin, password: admin; 
+$ python manage.py migrate # we have a fixture for the users...
+$ python manage.py loaddata deck/fixtures/user.json
+# username: admin, password: admin;
 # username: user, password: user
 $ python manage.py loaddata deck/fixtures/event.json
 $ python manage.py loaddata deck/fixtures/proposal.json


### PR DESCRIPTION
- Replacing syncdb --migrate for just 'migrate'
- Deleting trailing whitespaces