### PR TITLE
Voting ajax

### DIFF
--- a/core/static/js/voting.js
+++ b/core/static/js/voting.js
@@ -1,0 +1,39 @@
+$(function () {
+  $(".voting-link").on('click', function(e) {
+    e.preventDefault();
+    var $me = $(this);
+    if (!$me.attr('href')) {
+      return;
+    }
+
+    $.ajax({
+      url: $me.attr('href')
+    })
+    .success(function(data, status, xhr) {
+      $me.parent('.proposal-votes').find('.voting-link').not($me).remove();
+      $me.attr('href', '');
+      var successAlert = '<div class="alert alert-success alert-dismissable" id="succes-vote-alert">' +
+                          '<i class="icon-exclamation-sign"></i>' + data.message +
+                          '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>' +
+                        '</div>';
+      $me.parent('.proposal-votes').append(successAlert);
+      window.setTimeout(function() {
+        $("#succes-vote-alert").alert('close');
+      }, 3000);
+    })
+    .error(function(xhr, status, error) {
+      if (xhr.responseJSON) {
+        if (xhr.responseJSON.redirectUrl) {
+          window.location.href = xhr.responseJSON.redirectUrl;
+        } else if (xhr.responseJSON.errorMessage) {
+          var errorAlert = '<div class="alert alert-danger alert-dismissable">' +
+                              '<i class="icon-exclamation-sign"></i>' +
+                              xhr.responseJSON.errorMessage +
+                              '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>' +
+                            '</div>';
+          $me.parent('.proposal-votes').append(errorAlert);
+        }
+      }
+    });
+  });
+});

--- a/core/static/js/voting.js
+++ b/core/static/js/voting.js
@@ -7,7 +7,8 @@ $(function () {
     }
 
     $.ajax({
-      url: $me.attr('href')
+      url: $me.attr('href'),
+      method: 'POST'
     })
     .success(function(data, status, xhr) {
       $me.parent('.proposal-votes').find('.voting-link').not($me).remove();

--- a/deck/templates/event/event_detail.html
+++ b/deck/templates/event/event_detail.html
@@ -100,6 +100,25 @@
   <script type="text/javascript">
     $(function () {
       $(".linkable").linkable();
+
+      $(".voting-link").on('click', function(e) {
+        e.preventDefault();
+        var $me = $(this);
+        if ($me.attr('href')) {
+          $.ajax(
+            $me.attr('href')
+          ).success(function(data, status, xhr) {
+            $me.parent('.proposal-votes').find('.voting-link').not($me).remove()
+            $me.attr('href', '');
+          }).error(function(xhr, status, error) {
+            if (xhr.status == 405) {
+              window.location.href = xhr.responseText;
+            } else {
+              alert(error);
+            }
+          });
+        }
+      });
     });
   </script>
 {% endblock scripts %}

--- a/deck/templates/event/event_detail.html
+++ b/deck/templates/event/event_detail.html
@@ -96,29 +96,11 @@
 
 {% block scripts %}
   <script src="{{ STATIC_URL }}js/libs/jquery.linkable.js"></script>
+  <script src="{{ STATIC_URL }}js/voting.js"></script>
 
   <script type="text/javascript">
     $(function () {
       $(".linkable").linkable();
-
-      $(".voting-link").on('click', function(e) {
-        e.preventDefault();
-        var $me = $(this);
-        if ($me.attr('href')) {
-          $.ajax(
-            $me.attr('href')
-          ).success(function(data, status, xhr) {
-            $me.parent('.proposal-votes').find('.voting-link').not($me).remove();
-            $me.attr('href', '');
-          }).error(function(xhr, status, error) {
-            if (xhr.status == 401) {
-              window.location.href = xhr.responseText;
-            } else {
-              alert(error);
-            }
-          });
-        }
-      });
     });
   </script>
 {% endblock scripts %}

--- a/deck/templates/event/event_detail.html
+++ b/deck/templates/event/event_detail.html
@@ -111,7 +111,7 @@
             $me.parent('.proposal-votes').find('.voting-link').not($me).remove();
             $me.attr('href', '');
           }).error(function(xhr, status, error) {
-            if (xhr.status == 400) {
+            if (xhr.status == 401) {
               window.location.href = xhr.responseText;
             } else {
               alert(error);

--- a/deck/templates/event/event_detail.html
+++ b/deck/templates/event/event_detail.html
@@ -108,10 +108,10 @@
           $.ajax(
             $me.attr('href')
           ).success(function(data, status, xhr) {
-            $me.parent('.proposal-votes').find('.voting-link').not($me).remove()
+            $me.parent('.proposal-votes').find('.voting-link').not($me).remove();
             $me.attr('href', '');
           }).error(function(xhr, status, error) {
-            if (xhr.status == 405) {
+            if (xhr.status == 400) {
               window.location.href = xhr.responseText;
             } else {
               alert(error);

--- a/deck/templates/event/vote_block.html
+++ b/deck/templates/event/vote_block.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load deck_tags %}
 
-<div class="text-center">
+<div class="text-center proposal-votes">
   {% if request.user|already_voted:proposal %}
     {% with request.user|get_rate_display:proposal as rate %}
       <a class="flat-icon" title="{{ rate|title }}">
@@ -11,7 +11,7 @@
   {% elif request.user|allowed_to_vote:proposal %}
     Use the buttons bellow to vote:<br/>
     {% for value, name in vote_rates %}
-      <a href="{% url 'rate_proposal' event_slug=proposal.event.slug slug=proposal.slug rate=name %}" class="flat-icon">
+      <a href="{% url 'rate_proposal' event_slug=proposal.event.slug slug=proposal.slug rate=name %}" class="flat-icon voting-link">
         <i class="{{ name }} black" title="{{ name|title }}" data-toggle="tooltip"></i>
       </a>
     {% endfor %}

--- a/deck/tests/test_functional.py
+++ b/deck/tests/test_functional.py
@@ -1,4 +1,5 @@
 from django.test import TestCase, Client
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
@@ -529,7 +530,7 @@ class ProposalTest(TestCase):
             follow=True
         )
 
-        self.assertEquals(200, response.status_code)
+        self.assertEquals(405, response.status_code)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())
@@ -564,7 +565,7 @@ class ProposalTest(TestCase):
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
-        self.assertEquals(200, response.status_code)
+        self.assertEquals(405, response.status_code)
         self.assertEquals(1, Vote.objects.count())
         self.assertEquals(1, self.proposal.votes.count())
         self.assertEquals(3, self.proposal.rate)
@@ -585,7 +586,7 @@ class ProposalTest(TestCase):
             follow=True
         )
 
-        self.assertEquals(200, response.status_code)
+        self.assertEquals(405, response.status_code)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())
@@ -597,11 +598,14 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'sad'
         }
+        expected_content = u'{}?next={}'.format(
+            settings.LOGIN_URL,
+            reverse('view_event', kwargs={'slug': self.proposal.event.slug})
+        )
         proposal_rate_url = reverse('rate_proposal', kwargs=rate_proposal_data)
         response = self.client.get(proposal_rate_url, follow=True)
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(proposal_rate_url,
-                          response.context_data.get('redirect_field_value'))
+        self.assertEquals(405, response.status_code)
+        self.assertEquals(expected_content, response.content)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())

--- a/deck/tests/test_functional.py
+++ b/deck/tests/test_functional.py
@@ -530,7 +530,7 @@ class ProposalTest(TestCase):
             follow=True
         )
 
-        self.assertEquals(400, response.status_code)
+        self.assertEquals(401, response.status_code)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())
@@ -565,7 +565,7 @@ class ProposalTest(TestCase):
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
-        self.assertEquals(400, response.status_code)
+        self.assertEquals(401, response.status_code)
         self.assertEquals(1, Vote.objects.count())
         self.assertEquals(1, self.proposal.votes.count())
         self.assertEquals(3, self.proposal.rate)
@@ -586,7 +586,7 @@ class ProposalTest(TestCase):
             follow=True
         )
 
-        self.assertEquals(400, response.status_code)
+        self.assertEquals(401, response.status_code)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())
@@ -604,7 +604,7 @@ class ProposalTest(TestCase):
         )
         proposal_rate_url = reverse('rate_proposal', kwargs=rate_proposal_data)
         response = self.client.get(proposal_rate_url, follow=True)
-        self.assertEquals(400, response.status_code)
+        self.assertEquals(401, response.status_code)
         self.assertEquals(expected_content, response.content)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())

--- a/deck/tests/test_functional.py
+++ b/deck/tests/test_functional.py
@@ -1,5 +1,6 @@
+import json
+
 from django.test import TestCase, Client
-from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
@@ -546,7 +547,8 @@ class ProposalTest(TestCase):
             follow=True
         )
 
-        self.assertEquals(200, response.status_code)
+        self.assertEquals(400, response.status_code)
+        self.assertIn('errorMessage', json.loads(response.content))
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())
@@ -598,14 +600,11 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'sad'
         }
-        expected_content = u'{}?next={}'.format(
-            settings.LOGIN_URL,
-            reverse('view_event', kwargs={'slug': self.proposal.event.slug})
-        )
+
         proposal_rate_url = reverse('rate_proposal', kwargs=rate_proposal_data)
         response = self.client.get(proposal_rate_url, follow=True)
         self.assertEquals(401, response.status_code)
-        self.assertEquals(expected_content, response.content)
+        self.assertIn('errorMessage', json.loads(response.content))
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())

--- a/deck/tests/test_functional.py
+++ b/deck/tests/test_functional.py
@@ -418,7 +418,7 @@ class ProposalTest(TestCase):
             follow=True
         )
         self.assertEquals(200, response.status_code)
-        self.assertQuerysetEqual(response.context['event_proposals'], 
+        self.assertQuerysetEqual(response.context['event_proposals'],
                                  ['<Proposal: Python For Zombies>'])
 
     def test_list_proposal_without_public_voting(self):
@@ -530,7 +530,7 @@ class ProposalTest(TestCase):
             follow=True
         )
 
-        self.assertEquals(405, response.status_code)
+        self.assertEquals(400, response.status_code)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())
@@ -565,7 +565,7 @@ class ProposalTest(TestCase):
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
-        self.assertEquals(405, response.status_code)
+        self.assertEquals(400, response.status_code)
         self.assertEquals(1, Vote.objects.count())
         self.assertEquals(1, self.proposal.votes.count())
         self.assertEquals(3, self.proposal.rate)
@@ -586,7 +586,7 @@ class ProposalTest(TestCase):
             follow=True
         )
 
-        self.assertEquals(405, response.status_code)
+        self.assertEquals(400, response.status_code)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())
         self.assertEquals(0, Vote.objects.count())
@@ -604,7 +604,7 @@ class ProposalTest(TestCase):
         )
         proposal_rate_url = reverse('rate_proposal', kwargs=rate_proposal_data)
         response = self.client.get(proposal_rate_url, follow=True)
-        self.assertEquals(405, response.status_code)
+        self.assertEquals(400, response.status_code)
         self.assertEquals(expected_content, response.content)
         self.assertEquals(0, self.proposal.rate)
         self.assertEquals(0, self.proposal.votes.count())

--- a/deck/tests/test_functional.py
+++ b/deck/tests/test_functional.py
@@ -504,7 +504,7 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'laughing'
         }
-        response = self.client.get(
+        response = self.client.post(
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
@@ -526,7 +526,7 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'sad'
         }
-        response = self.client.get(
+        response = self.client.post(
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
@@ -542,7 +542,7 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'whatever'
         }
-        response = self.client.get(
+        response = self.client.post(
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
@@ -559,11 +559,13 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'laughing'
         }
-        self.client.get(reverse('rate_proposal', kwargs=rate_proposal_data),
-                        follow=True)
+        self.client.post(
+            reverse('rate_proposal', kwargs=rate_proposal_data),
+            follow=True
+        )
 
         rate_proposal_data.update({'rate': 'happy'})
-        response = self.client.get(
+        response = self.client.post(
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
@@ -583,7 +585,7 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'sad'
         }
-        response = self.client.get(
+        response = self.client.post(
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
@@ -620,7 +622,7 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'sad'
         }
-        response = self.client.get(
+        response = self.client.post(
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )
@@ -640,7 +642,7 @@ class ProposalTest(TestCase):
             'slug': self.proposal.slug,
             'rate': 'sad'
         }
-        response = self.client.get(
+        response = self.client.post(
             reverse('rate_proposal', kwargs=rate_proposal_data),
             follow=True
         )

--- a/deck/views.py
+++ b/deck/views.py
@@ -199,10 +199,10 @@ class RateProposal(BaseProposalView, UpdateView):
                 settings.LOGIN_URL,
                 reverse('view_event', kwargs={'slug': proposal.event.slug})
             )
-            return HttpResponse(response_url, status=405)
+            return HttpResponse(response_url, status=400)
 
         if not proposal.user_can_vote(self.request.user):
             messages.error(
                 self.request, _(u'You are not allowed to see this page.'))
-            return HttpResponse(reverse('view_event', kwargs={'slug': proposal.event.slug}), status=405)
+            return HttpResponse(reverse('view_event', kwargs={'slug': proposal.event.slug}), status=400)
         return super(RateProposal, self).dispatch(*args, **kwargs)

--- a/deck/views.py
+++ b/deck/views.py
@@ -179,7 +179,7 @@ class UpdateProposal(BaseProposalView, UpdateView):
 
 
 class RateProposal(BaseProposalView, UpdateView):
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         rate = kwargs.get('rate')
         response_content = {}

--- a/deck/views.py
+++ b/deck/views.py
@@ -199,10 +199,9 @@ class RateProposal(BaseProposalView, UpdateView):
                 settings.LOGIN_URL,
                 reverse('view_event', kwargs={'slug': proposal.event.slug})
             )
-            return HttpResponse(response_url, status=400)
+            return HttpResponse(response_url, status=401)
 
         if not proposal.user_can_vote(self.request.user):
-            messages.error(
-                self.request, _(u'You are not allowed to see this page.'))
-            return HttpResponse(reverse('view_event', kwargs={'slug': proposal.event.slug}), status=400)
+            messages.error(self.request, _(u'You are not allowed to see this page.'))
+            return HttpResponse(reverse('view_event', kwargs={'slug': proposal.event.slug}), status=401)
         return super(RateProposal, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
This PR is intended to solve the issue https://github.com/luanfonceca/speakerfight/issues/46.

* The "view" do not use "django messages" anymore because all communications are done asynchronously. The same messages were preserved, but now they are sent in a json response.
* All client-side code to deal with ajax vote was created in a file called voting.js.
* Looking for a more semantic api, the http method used to vote now is POST instead GET.
* The flow to a non-logged User to vote is:
    * He try to vote > He is redirected to login form > He is sent back to the Event Detail Page (allowed to vote)

ps.: As we was talking about this issue in chats, I decided to open this PR and continue any conversation here for the records.