### PR TITLE
Change Travis to use old infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language:
 - python
 install:


### PR DESCRIPTION
To make this Travis configuration work it needs sudo set to false.
More info available here: http://docs.travis-ci.com/user/migrating-from-legacy/