### PR TITLE
Add remove proposal feature

### DIFF
--- a/deck/templates/event/event_detail.html
+++ b/deck/templates/event/event_detail.html
@@ -108,6 +108,9 @@
                     <a href="{% url 'update_proposal' event_slug=event.slug slug=proposal.slug %}" class="btn-flat gray text-upper" data-toggle="tooltip" title="{% trans 'Edit the proposal.' %}">
                       <i class="icon-pencil"></i> {% trans "Edit" %}
                     </a>
+                    <a href="{% url 'delete_proposal' event_slug=event.slug slug=proposal.slug %}" class="btn-flat gray text-upper" data-toggle="tooltip" title="{% trans 'Delete the proposal.' %}">
+                      <i class="icon-trash"></i> {% trans "Delete" %}
+                    </a>
                 {% endif %}
               </div>
             {% endif %}

--- a/deck/templates/proposal/proposal_confirm_delete.html
+++ b/deck/templates/proposal/proposal_confirm_delete.html
@@ -1,0 +1,32 @@
+{% extends "layout.html" %}
+
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block head_title %}{% trans "Delete Proposal" %}: "{{ object }}"{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <h1>{% trans "Delete Proposal" %}: "{{ object }}"</h1>
+    <p>{% trans "Are you sure you want to delete this proposal?" %}</p>
+    <p>{% trans "After deleting this proposal all votes will be lost forever." %}</p>
+    <form method="POST">
+      {% buttons %}
+        <button type="submit" class="btn-flat success text-upper">
+          <i class="icon icon-trash"></i>
+          {% trans "Delete" %}
+        </button>
+        <div class="pull-right">
+          <a href="{% url 'view_event' slug=object.event.slug %}" class="link text-upper">
+            <i class="icon-calendar"></i>
+            {% trans "event detail" %}
+          </a> |
+          <a href="{% url 'list_events' %}" class="link text-upper">
+            <i class="icon-calendar-empty"></i>
+            {% trans "event list" %}
+          </a>
+        </div>
+      {% endbuttons %}
+    </form>
+  </div>
+{% endblock content %}

--- a/deck/urls.py
+++ b/deck/urls.py
@@ -29,6 +29,10 @@ urlpatterns = patterns(
         view=views.UpdateProposal.as_view(),
         name='update_proposal'),
     url(regex=r'/events/<slug:event_slug>/'
+              r'proposals/<slug:slug>/delete/',
+        view=views.DeleteProposal.as_view(),
+        name='delete_proposal'),
+    url(regex=r'/events/<slug:event_slug>/'
               r'proposals/<slug:slug>/rate/<slug:rate>/',
         view=views.RateProposal.as_view(),
         name='rate_proposal'),


### PR DESCRIPTION
This commit adds a possibility to proposal authors delete them.
Also superusers are able to delete any proposal.
Added a new template to serve as a confirmation page.
Some tests were added to prove that the feature is working fine.