### PR TITLE
Add notification when proposals get deleted

### DIFF
--- a/deck/templates/mailing/jury_deleted_proposal.txt
+++ b/deck/templates/mailing/jury_deleted_proposal.txt
@@ -1,0 +1,7 @@
+{% load i18n %}
+
+{% blocktrans %}
+  Hi!
+
+  This email is a notification that the following proposal was deleted from your event "{{ event_title }}" on SpeakerFight: {{ proposal_title }}
+{% endblocktrans %}


### PR DESCRIPTION
Send notification to jury when a proposal is deleted.
Added tests to assert email contains context variables passed to send_mail function.