### PR TITLE
fix #106 - Adding alert confirmation when trying to remove an activity from schedule

### DIFF
--- a/core/static/js/event-grade.js
+++ b/core/static/js/event-grade.js
@@ -159,6 +159,11 @@ $(function () {
     e.preventDefault();
     var self = this;
 
+    var message = gettext('Are you sure you want to remove this activity?');
+    if (!confirm(message)) {
+      return false;
+    }
+
     $.ajax({
       url: $(this).parents('.panel').attr('data-href'),
       type: 'DELETE',


### PR DESCRIPTION
Added an alert confirmation.

(in this place it was supposed to have a screen shot, but due to an issue with my ISP I can't upload images to Github, I think it's something related to the international routes)