### PR TITLE
Removes the horizontal scrollbar

### DIFF
--- a/core/static/css/layout.css
+++ b/core/static/css/layout.css
@@ -5,6 +5,7 @@ body {
   margin: 0px;
   font-size: 12px;
   padding: 0px;
+  overflow-x: hidden;
   /*-webkit-font-smoothing: antialiased;*/ }
 
 h1, h2, h3, h4, h5 {


### PR DESCRIPTION
The overflow property has default value as 'visible', any minimal extra space the browser would make the horizontal scrollbar appear and the property is not inherited so there's no problem to put the value in the body