### PR TITLE
Collapses long proposal descriptions

### DIFF
--- a/core/static/css/layout.css
+++ b/core/static/css/layout.css
@@ -662,3 +662,23 @@ html {
   width: 40px;
   height: 40px;
 }
+
+.proposal-description {
+    position: relative;
+    overflow: hidden;
+}
+
+.proposal-description.proposal-collapse {
+    max-height: 150px;
+    cursor: pointer;
+}
+
+.proposal-description.proposal-collapse:after {
+    position: absolute;
+    content: '';
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 50px;
+    background: linear-gradient(rgba(255,255,255,0),#fff);
+}

--- a/deck/templates/event/event_detail.html
+++ b/deck/templates/event/event_detail.html
@@ -156,6 +156,14 @@
   <script type="text/javascript">
     $(function () {
       $(".linkable").linkable();
+      $(".proposal-description").each(function() {
+        if ($(this).height() > 150) {
+          $(this).addClass("proposal-collapse");
+        }
+      });
+      $(".proposal-collapse").click(function() {
+        $(this).removeClass("proposal-collapse");
+      });
     });
   </script>
 {% endblock scripts %}


### PR DESCRIPTION
Some descriptions are so long that we get tired of scrolling to see the
next proposal. With this change, we see by default only a small part
where each description begins.

See this [comment](https://github.com/luanfonceca/speakerfight/issues/140#issuecomment-252403142) in the issue #140 for understanding the changes.