### PR TITLE
Pinning pycparser to version 2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ uWSGI==2.0.5
 wsgiref==0.1.2
 smarturls==0.1.3
 Fabric==1.9.0
+pycparser==2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ uWSGI==2.0.5
 wsgiref==0.1.2
 smarturls==0.1.3
 Fabric==1.9.0
-pycparser==2.14
+pycparser==2.16


### PR DESCRIPTION
As proposed on other projects(Kitware/candela#452 and pyca/cryptography#3187) i pinned pycparser to version 2.14 to avoid the compile error on module cryptography