### PR TITLE
Fix issue #69

### DIFF
--- a/core/templates/account/password_reset.html
+++ b/core/templates/account/password_reset.html
@@ -13,9 +13,20 @@
     {% if user.is_authenticated %}
       {% include "account/snippets/already_logged_in.html" %}
     {% endif %}
-    
+
     <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
-    
+
+    {% for field in form %}
+      {% if field.errors %}
+        <div>
+          <div class="alert alert-danger alert-dismissable">
+            {{ field.errors|striptags }}
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+
     <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
       {% csrf_token %}
       {% bootstrap_form form layout="inline" %}
@@ -25,7 +36,7 @@
         </button>
       {% endbuttons %}
     </form>
-    
+
     <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
   </div>
 {% endblock %}


### PR DESCRIPTION
Issue: Password reset template does not show error messages.
Fix: Add form field errors treatment in password reset template.

![captura de tela de 2016-12-13 01-19-19](https://cloud.githubusercontent.com/assets/2524981/21126460/6aab8074-c0d3-11e6-81fe-1f6a1eab97ef.png)

