### PR TITLE
Fix issue #69

### DIFF
--- a/core/templates/account/password_reset.html
+++ b/core/templates/account/password_reset.html
@@ -13,9 +13,11 @@
     {% if user.is_authenticated %}
       {% include "account/snippets/already_logged_in.html" %}
     {% endif %}
-    
+
     <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
-    
+
+    {% include "snippets/render_form_error.html" %}
+
     <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
       {% csrf_token %}
       {% bootstrap_form form layout="inline" %}
@@ -25,7 +27,7 @@
         </button>
       {% endbuttons %}
     </form>
-    
+
     <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
   </div>
 {% endblock %}

--- a/core/templates/account/signup.html
+++ b/core/templates/account/signup.html
@@ -8,21 +8,12 @@
 {% block head_title %}{% trans "Sign Up" %}{% endblock %}
 
 {% block content %}
-  {% for field in form %}
-    {% if field.errors %}
-      <div class="col-md-12">
-        <div class="alert alert-danger alert-dismissable">
-          <i class="icon-remove-sign"></i>
-          {{ field.errors|striptags }}
-          <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
-        </div>
-      </div>
-    {% endif %}
-  {% endfor %}
   <div class="col-md-offset-3 col-md-6">
     <h1>{% trans "Sign Up" %}</h1>
 
     <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
+
+    {% include "snippets/render_form_error.html" %}
 
     <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
       {% csrf_token %}

--- a/core/templates/snippets/render_form_error.html
+++ b/core/templates/snippets/render_form_error.html
@@ -1,0 +1,10 @@
+{% for field in form %}
+  {% if field.errors %}
+    <div>
+      <div class="alert alert-danger alert-dismissable alert-link">
+        {{ field.errors|striptags }}
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
+      </div>
+    </div>
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
Issue: Password reset template does not show error messages.
Fix: Create a DRY form error template and replace where there need form error treatment.

![captura de tela de 2016-12-14 00-49-16](https://cloud.githubusercontent.com/assets/2524981/21167960/7510dd10-c197-11e6-85c5-38903ce6c566.png)

![captura de tela de 2016-12-14 00-49-01](https://cloud.githubusercontent.com/assets/2524981/21167963/79dc0a22-c197-11e6-89b3-287fe6e968ab.png)
