### PR TITLE
[Bug] Fix search results count bug

### DIFF
--- a/deck/templates/event/event_list.html
+++ b/deck/templates/event/event_list.html
@@ -46,10 +46,8 @@
       <div class="row-fluid">
         <div class="col-md-12">
           <p>
-            {% blocktrans count event_list.paginator.count as counter %}
-              Found {{ counter }} event matching your search for '{{ criteria }}'
-              {% plural %}
-              Found {{ counter }} events matching your search for '{{ criteria }}'
+            {% blocktrans with events_count=event_list.paginator.count events_pluralize=event_list.paginator.count|pluralize %}
+              Found {{ events_count }} event{{ events_pluralize }} matching your search for '{{ criteria }}'
             {% endblocktrans %}
           </p>
         </div>

--- a/deck/templates/event/event_list.html
+++ b/deck/templates/event/event_list.html
@@ -46,8 +46,10 @@
       <div class="row-fluid">
         <div class="col-md-12">
           <p>
-            {% blocktrans with counter=event_list.count %}
-              Found {{ counter }} event{{ counter|pluralize }} matching your search for '{{ criteria }}'
+            {% blocktrans count event_list.paginator.count as counter %}
+              Found {{ counter }} event matching your search for '{{ criteria }}'
+              {% plural %}
+              Found {{ counter }} events matching your search for '{{ criteria }}'
             {% endblocktrans %}
           </p>
         </div>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-15 21:01-0300\n"
+"POT-Creation-Date: 2017-09-19 14:12-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,9 +17,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: api/permissions.py:10 deck/tests/test_functional.py:740 deck/views.py:139
-#: deck/views.py:153 deck/views.py:191 deck/views.py:359 deck/views.py:423
-#: deck/views.py:490 deck/views.py:557
+#: api/permissions.py:10 deck/tests/test_functional.py:740 deck/views.py:140
+#: deck/views.py:154 deck/views.py:192 deck/views.py:360 deck/views.py:424
+#: deck/views.py:491 deck/views.py:558
 msgid "You are not allowed to see this page."
 msgstr ""
 
@@ -792,8 +792,8 @@ msgstr ""
 msgid "OpenID Sign In"
 msgstr ""
 
-#: core/templates/public_layout.html:55 deck/views.py:406 deck/views.py:473
-#: deck/views.py:540
+#: core/templates/public_layout.html:55 deck/views.py:407 deck/views.py:474
+#: deck/views.py:541
 msgid "You need to be logged in to continue to the next step."
 msgstr ""
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "More information"
 msgstr ""
 
-#: deck/models.py:193 deck/tests/test_functional.py:349 deck/views.py:272
+#: deck/models.py:193 deck/tests/test_functional.py:349 deck/views.py:273
 msgid "This Event doesn't accept Proposals anymore."
 msgstr ""
 
@@ -1283,18 +1283,24 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Found %(counter)s event%(counter|pluralize)s matching your "
-"search for '%(criteria)s'\n"
+"              Found %(counter)s event matching your search for "
+"'%(criteria)s'\n"
+"              "
+msgid_plural ""
+"\n"
+"              Found %(counter)s events matching your search for "
+"'%(criteria)s'\n"
 "            "
-msgstr ""
+msgstr[0] ""
+msgstr[1] ""
 
-#: deck/templates/event/event_list.html:61
+#: deck/templates/event/event_list.html:63
 #: deck/templates/event/my_events.html:25
 msgid "There are no events to show to you :("
 msgstr ""
 
-#: deck/templates/event/event_list.html:65
-#: deck/templates/event/event_list.html:66
+#: deck/templates/event/event_list.html:67
+#: deck/templates/event/event_list.html:68
 msgid "Back to the event list"
 msgstr ""
 
@@ -1481,67 +1487,67 @@ msgstr ""
 msgid "See in Event"
 msgstr ""
 
-#: deck/tests/test_functional.py:730 deck/views.py:350
+#: deck/tests/test_functional.py:730 deck/views.py:351
 msgid "Proposal deleted."
 msgstr ""
 
-#: deck/views.py:89
+#: deck/views.py:90
 msgid "Event created."
 msgstr ""
 
-#: deck/views.py:95
+#: deck/views.py:96
 msgid "Your event is ready to receive proposals"
 msgstr ""
 
-#: deck/views.py:131
+#: deck/views.py:132
 msgid "Event updated."
 msgstr ""
 
-#: deck/views.py:161
+#: deck/views.py:162
 msgid "Author"
 msgstr ""
 
-#: deck/views.py:162
+#: deck/views.py:163
 msgid "Author E-Mail"
 msgstr ""
 
-#: deck/views.py:163
+#: deck/views.py:164
 msgid "Vote Rate"
 msgstr ""
 
-#: deck/views.py:164
+#: deck/views.py:165
 msgid "Votes Count"
 msgstr ""
 
-#: deck/views.py:295
+#: deck/views.py:296
 msgid "Proposal created."
 msgstr ""
 
-#: deck/views.py:304
+#: deck/views.py:305
 msgid "Your event has new proposals"
 msgstr ""
 
-#: deck/views.py:316
+#: deck/views.py:317
 msgid "Your proposal was submitted"
 msgstr ""
 
-#: deck/views.py:341
+#: deck/views.py:342
 msgid "Proposal updated."
 msgstr ""
 
-#: deck/views.py:374 deck/views.py:393
+#: deck/views.py:375 deck/views.py:394
 msgid "Rate Index not found."
 msgstr ""
 
-#: deck/views.py:380 deck/views.py:397
+#: deck/views.py:381 deck/views.py:398
 msgid "Proposal rated."
 msgstr ""
 
-#: deck/views.py:450 deck/views.py:464
+#: deck/views.py:451 deck/views.py:465
 msgid "Proposal approved."
 msgstr ""
 
-#: deck/views.py:517 deck/views.py:531
+#: deck/views.py:518 deck/views.py:532
 msgid "Proposal disapproved."
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-19 14:12-0300\n"
+"POT-Creation-Date: 2017-09-20 09:13-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1283,24 +1283,18 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Found %(counter)s event matching your search for "
-"'%(criteria)s'\n"
-"              "
-msgid_plural ""
-"\n"
-"              Found %(counter)s events matching your search for "
-"'%(criteria)s'\n"
+"              Found %(events_count)s event%(events_pluralize)s matching your "
+"search for '%(criteria)s'\n"
 "            "
-msgstr[0] ""
-msgstr[1] ""
+msgstr ""
 
-#: deck/templates/event/event_list.html:63
+#: deck/templates/event/event_list.html:61
 #: deck/templates/event/my_events.html:25
 msgid "There are no events to show to you :("
 msgstr ""
 
-#: deck/templates/event/event_list.html:67
-#: deck/templates/event/event_list.html:68
+#: deck/templates/event/event_list.html:65
+#: deck/templates/event/event_list.html:66
 msgid "Back to the event list"
 msgstr ""
 
@@ -1611,9 +1605,5 @@ msgid "The \"@%s\" was successfully removed from the Jury."
 msgstr ""
 
 #: speakerfight/settings.py:138
-msgid "English"
-msgstr ""
-
-#: speakerfight/settings.py:139
 msgid "Portuguese"
 msgstr ""

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: speakerfight\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-19 14:12-0300\n"
+"POT-Creation-Date: 2017-09-20 09:13-0300\n"
 "PO-Revision-Date: 2017-09-15 21:02-0300\n"
 "Last-Translator: Luan Fonseca de Farias <luanfonceca@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/speakerfight/"
@@ -1466,40 +1466,30 @@ msgid "new event"
 msgstr "novo evento"
 
 #: deck/templates/event/event_list.html:49
-#, fuzzy, python-format
+#, python-format
 #| msgid ""
 #| "\n"
-#| "              Found %(counter)s event%(counter|pluralize)s matching your "
-#| "search for '%(criteria)s'\n"
+#| "              Found %(events_count)s event%(events_pluralize)s matching "
+#| "your search for '%(criteria)s'\n"
 #| "            "
 msgid ""
 "\n"
-"              Found %(counter)s event matching your search for "
-"'%(criteria)s'\n"
-"              "
-msgid_plural ""
-"\n"
-"              Found %(counter)s events matching your search for "
-"'%(criteria)s'\n"
+"              Found %(events_count)s event%(events_pluralize)s matching your "
+"search for '%(criteria)s'\n"
 "            "
-msgstr[0] ""
+msgstr ""
 "\n"
-"              Encontrados %(counter)s evento%(counter|pluralize)s contendo o "
-"termo ‘%(criteria)s’\n"
-"            "
-msgstr[1] ""
-"\n"
-"              Encontrados %(counter)s evento%(counter|pluralize)s contendo o "
-"termo ‘%(criteria)s’\n"
+"              Encontrados %(events_count)s evento%(events_pluralize)s "
+"contendo o termo '%(criteria)s'\n"
 "            "
 
-#: deck/templates/event/event_list.html:63
+#: deck/templates/event/event_list.html:61
 #: deck/templates/event/my_events.html:25
 msgid "There are no events to show to you :("
 msgstr "Não há eventos para te exibir :("
 
-#: deck/templates/event/event_list.html:67
-#: deck/templates/event/event_list.html:68
+#: deck/templates/event/event_list.html:65
+#: deck/templates/event/event_list.html:66
 msgid "Back to the event list"
 msgstr "Voltar para a lista de eventos"
 
@@ -1866,12 +1856,11 @@ msgid "The \"@%s\" was successfully removed from the Jury."
 msgstr "Os \"@%s\" foram removidos do júri com sucesso."
 
 #: speakerfight/settings.py:138
-msgid "English"
-msgstr "Inglês"
-
-#: speakerfight/settings.py:139
 msgid "Portuguese"
 msgstr "Português"
+
+#~ msgid "English"
+#~ msgstr "Inglês"
 
 #~ msgid ""
 #~ "\n"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: speakerfight\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-15 21:01-0300\n"
+"POT-Creation-Date: 2017-09-19 14:12-0300\n"
 "PO-Revision-Date: 2017-09-15 21:02-0300\n"
 "Last-Translator: Luan Fonseca de Farias <luanfonceca@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/speakerfight/"
@@ -22,9 +22,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.2\n"
 
-#: api/permissions.py:10 deck/tests/test_functional.py:740 deck/views.py:139
-#: deck/views.py:153 deck/views.py:191 deck/views.py:359 deck/views.py:423
-#: deck/views.py:490 deck/views.py:557
+#: api/permissions.py:10 deck/tests/test_functional.py:740 deck/views.py:140
+#: deck/views.py:154 deck/views.py:192 deck/views.py:360 deck/views.py:424
+#: deck/views.py:491 deck/views.py:558
 msgid "You are not allowed to see this page."
 msgstr "Você não tem permissão para ver esta página."
 
@@ -934,8 +934,8 @@ msgstr "Buscar Eventos"
 msgid "OpenID Sign In"
 msgstr "Acesso OpenID"
 
-#: core/templates/public_layout.html:55 deck/views.py:406 deck/views.py:473
-#: deck/views.py:540
+#: core/templates/public_layout.html:55 deck/views.py:407 deck/views.py:474
+#: deck/views.py:541
 msgid "You need to be logged in to continue to the next step."
 msgstr "Você precisa estar logado para ir para o próximo passo."
 
@@ -1184,7 +1184,7 @@ msgstr "Aprovada"
 msgid "More information"
 msgstr "Mais informações"
 
-#: deck/models.py:193 deck/tests/test_functional.py:349 deck/views.py:272
+#: deck/models.py:193 deck/tests/test_functional.py:349 deck/views.py:273
 msgid "This Event doesn't accept Proposals anymore."
 msgstr "Este evento não aceita mais propostas."
 
@@ -1466,25 +1466,40 @@ msgid "new event"
 msgstr "novo evento"
 
 #: deck/templates/event/event_list.html:49
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "              Found %(counter)s event%(counter|pluralize)s matching your "
+#| "search for '%(criteria)s'\n"
+#| "            "
 msgid ""
 "\n"
-"              Found %(counter)s event%(counter|pluralize)s matching your "
-"search for '%(criteria)s'\n"
+"              Found %(counter)s event matching your search for "
+"'%(criteria)s'\n"
+"              "
+msgid_plural ""
+"\n"
+"              Found %(counter)s events matching your search for "
+"'%(criteria)s'\n"
 "            "
-msgstr ""
+msgstr[0] ""
+"\n"
+"              Encontrados %(counter)s evento%(counter|pluralize)s contendo o "
+"termo ‘%(criteria)s’\n"
+"            "
+msgstr[1] ""
 "\n"
 "              Encontrados %(counter)s evento%(counter|pluralize)s contendo o "
 "termo ‘%(criteria)s’\n"
 "            "
 
-#: deck/templates/event/event_list.html:61
+#: deck/templates/event/event_list.html:63
 #: deck/templates/event/my_events.html:25
 msgid "There are no events to show to you :("
 msgstr "Não há eventos para te exibir :("
 
-#: deck/templates/event/event_list.html:65
-#: deck/templates/event/event_list.html:66
+#: deck/templates/event/event_list.html:67
+#: deck/templates/event/event_list.html:68
 msgid "Back to the event list"
 msgstr "Voltar para a lista de eventos"
 
@@ -1723,67 +1738,67 @@ msgstr "Veja a proposta no Evento."
 msgid "See in Event"
 msgstr "Ver no Evento"
 
-#: deck/tests/test_functional.py:730 deck/views.py:350
+#: deck/tests/test_functional.py:730 deck/views.py:351
 msgid "Proposal deleted."
 msgstr "Proposta removida."
 
-#: deck/views.py:89
+#: deck/views.py:90
 msgid "Event created."
 msgstr "Evento criado."
 
-#: deck/views.py:95
+#: deck/views.py:96
 msgid "Your event is ready to receive proposals"
 msgstr "Seu evento está pronto para receber propostas"
 
-#: deck/views.py:131
+#: deck/views.py:132
 msgid "Event updated."
 msgstr "Evento Atualizado."
 
-#: deck/views.py:161
+#: deck/views.py:162
 msgid "Author"
 msgstr "Autor"
 
-#: deck/views.py:162
+#: deck/views.py:163
 msgid "Author E-Mail"
 msgstr "Email do Autor"
 
-#: deck/views.py:163
+#: deck/views.py:164
 msgid "Vote Rate"
 msgstr "Índice de Votos"
 
-#: deck/views.py:164
+#: deck/views.py:165
 msgid "Votes Count"
 msgstr "Quantidade de Votos"
 
-#: deck/views.py:295
+#: deck/views.py:296
 msgid "Proposal created."
 msgstr "Proposta criada."
 
-#: deck/views.py:304
+#: deck/views.py:305
 msgid "Your event has new proposals"
 msgstr "Seu evento recebeu novas propostas"
 
-#: deck/views.py:316
+#: deck/views.py:317
 msgid "Your proposal was submitted"
 msgstr "Sua proposta foi submetida"
 
-#: deck/views.py:341
+#: deck/views.py:342
 msgid "Proposal updated."
 msgstr "Proposta Atualizada."
 
-#: deck/views.py:374 deck/views.py:393
+#: deck/views.py:375 deck/views.py:394
 msgid "Rate Index not found."
 msgstr "Índice de classificação não encontrado."
 
-#: deck/views.py:380 deck/views.py:397
+#: deck/views.py:381 deck/views.py:398
 msgid "Proposal rated."
 msgstr "Proposta classificada."
 
-#: deck/views.py:450 deck/views.py:464
+#: deck/views.py:451 deck/views.py:465
 msgid "Proposal approved."
 msgstr "Proposta aprovada."
 
-#: deck/views.py:517 deck/views.py:531
+#: deck/views.py:518 deck/views.py:532
 msgid "Proposal disapproved."
 msgstr "Proposta desaprovada."
 


### PR DESCRIPTION
Issue: https://github.com/luanfonceca/speakerfight/issues/218

Decisions:
- The right `count` attribute was inside the `paginator` object.
- The pluralize filter does not work inside a block `trans`. The only way I found to make it work was checking the plural passing `count` as an argument to the `trans` block and using the `plural` template tag for each case. You used this Stackoverflow [answer](https://stackoverflow.com/a/2929822) as base.