### PR TITLE
Enable remove organizations

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-04 16:35-0300\n"
+"POT-Creation-Date: 2017-10-05 14:21-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: core/forms.py:14 organization/models.py:14
+#: core/forms.py:14 organization/models.py:16
 msgid "Name"
 msgstr ""
 
@@ -284,6 +284,7 @@ msgstr ""
 
 #: core/templates/account/email.html:36
 #: core/templates/socialaccount/connections.html:35
+#: organization/templates/organization/organization_confirm_delete.html:13
 msgid "Remove"
 msgstr ""
 
@@ -1102,6 +1103,8 @@ msgstr ""
 #: deck/templates/event/snippets/event_list_item.html:54
 #: deck/templates/proposal/proposal_confirm_delete.html:18
 #: deck/templates/proposal/snippets/proposal_list_item.html:29
+#: organization/templates/organization/organization_confirm_delete.html:17
+#: organization/templates/organization/organization_confirm_delete.html:25
 msgid "Delete"
 msgstr ""
 
@@ -1122,6 +1125,7 @@ msgstr ""
 #: deck/templates/event/event_form.html:23
 #: deck/templates/proposal/proposal_form.html:22
 #: jury/templates/jury/jury_detail.html:45
+#: organization/templates/organization/organization_confirm_delete.html:10
 #: organization/templates/organization/organization_form.html:23
 msgid "Home"
 msgstr ""
@@ -1293,6 +1297,7 @@ msgstr ""
 #: jury/templates/jury/jury_detail.html:8
 #: jury/templates/jury/jury_detail.html:56
 #: organization/templates/organization/organization_form.html:9
+#: organization/templates/organization/organization_form.html:27
 #: organization/templates/organization/organization_form.html:36
 msgid "Update"
 msgstr ""
@@ -1661,25 +1666,47 @@ msgstr ""
 msgid "The \"@%s\" was successfully removed from the Jury."
 msgstr ""
 
-#: organization/models.py:18
+#: organization/models.py:20
 msgid "About"
 msgstr ""
 
-#: organization/templates/organization/organization_form.html:11
-#: organization/templates/organization/organization_form.html:38
-msgid "New Organization"
+#: organization/templates/organization/organization_confirm_delete.html:6
+msgid "Delete Organization"
 msgstr ""
 
+#: organization/templates/organization/organization_confirm_delete.html:11
 #: organization/templates/organization/organization_form.html:24
 msgid "Organizations"
 msgstr ""
 
-#: organization/views.py:22
+#: organization/templates/organization/organization_confirm_delete.html:18
+msgid "Are you sure you want to delete this organization?"
+msgstr ""
+
+#: organization/templates/organization/organization_confirm_delete.html:19
+msgid "After deleting this organization all events will be lost forever."
+msgstr ""
+
+#: organization/templates/organization/organization_confirm_delete.html:30
+msgid "organization detail"
+msgstr ""
+
+#: organization/templates/organization/organization_form.html:11
+#: organization/templates/organization/organization_form.html:29
+#: organization/templates/organization/organization_form.html:38
+msgid "New Organization"
+msgstr ""
+
+#: organization/views.py:27
 msgid "Organization created."
 msgstr ""
 
-#: organization/views.py:37
+#: organization/views.py:33
 msgid "Organization updated."
+msgstr ""
+
+#: organization/views.py:40
+msgid "Organization deleted."
 msgstr ""
 
 #: speakerfight/settings.py:140

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: speakerfight\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-04 16:35-0300\n"
+"POT-Creation-Date: 2017-10-05 14:21-0300\n"
 "PO-Revision-Date: 2017-10-04 16:45-0300\n"
 "Last-Translator: Luan Fonseca de Farias <luanfonceca@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/speakerfight/"
@@ -33,7 +33,7 @@ msgstr "Você não tem permissão para ver esta página."
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: core/forms.py:14 organization/models.py:14
+#: core/forms.py:14 organization/models.py:16
 msgid "Name"
 msgstr "Nome"
 
@@ -343,6 +343,7 @@ msgstr "Reenviar verificação"
 
 #: core/templates/account/email.html:36
 #: core/templates/socialaccount/connections.html:35
+#: organization/templates/organization/organization_confirm_delete.html:13
 msgid "Remove"
 msgstr "Remover"
 
@@ -1258,6 +1259,8 @@ msgstr ""
 #: deck/templates/event/snippets/event_list_item.html:54
 #: deck/templates/proposal/proposal_confirm_delete.html:18
 #: deck/templates/proposal/snippets/proposal_list_item.html:29
+#: organization/templates/organization/organization_confirm_delete.html:17
+#: organization/templates/organization/organization_confirm_delete.html:25
 msgid "Delete"
 msgstr "Remover"
 
@@ -1278,6 +1281,7 @@ msgstr "Crie a Grade"
 #: deck/templates/event/event_form.html:23
 #: deck/templates/proposal/proposal_form.html:22
 #: jury/templates/jury/jury_detail.html:45
+#: organization/templates/organization/organization_confirm_delete.html:10
 #: organization/templates/organization/organization_form.html:23
 msgid "Home"
 msgstr "Início"
@@ -1480,6 +1484,7 @@ msgstr "Mais"
 #: jury/templates/jury/jury_detail.html:8
 #: jury/templates/jury/jury_detail.html:56
 #: organization/templates/organization/organization_form.html:9
+#: organization/templates/organization/organization_form.html:27
 #: organization/templates/organization/organization_form.html:36
 msgid "Update"
 msgstr "Atualizar"
@@ -1912,26 +1917,48 @@ msgstr "O  \"@user\" foi removido do júri com sucesso."
 msgid "The \"@%s\" was successfully removed from the Jury."
 msgstr "Os \"@%s\" foram removidos do júri com sucesso."
 
-#: organization/models.py:18
+#: organization/models.py:20
 msgid "About"
 msgstr "Sobre"
 
-#: organization/templates/organization/organization_form.html:11
-#: organization/templates/organization/organization_form.html:38
-msgid "New Organization"
-msgstr "Nova Organização"
+#: organization/templates/organization/organization_confirm_delete.html:6
+msgid "Delete Organization"
+msgstr "Remover Organização"
 
+#: organization/templates/organization/organization_confirm_delete.html:11
 #: organization/templates/organization/organization_form.html:24
 msgid "Organizations"
 msgstr "Organizações"
 
-#: organization/views.py:22
+#: organization/templates/organization/organization_confirm_delete.html:18
+msgid "Are you sure you want to delete this organization?"
+msgstr "Você tem certeza que deseja remover esta organização?"
+
+#: organization/templates/organization/organization_confirm_delete.html:19
+msgid "After deleting this organization all events will be lost forever."
+msgstr "Após remover esta organização todos os eventos serão perdidos para sempre."
+
+#: organization/templates/organization/organization_confirm_delete.html:30
+msgid "organization detail"
+msgstr "detalhe da organização"
+
+#: organization/templates/organization/organization_form.html:11
+#: organization/templates/organization/organization_form.html:29
+#: organization/templates/organization/organization_form.html:38
+msgid "New Organization"
+msgstr "Nova Organização"
+
+#: organization/views.py:27
 msgid "Organization created."
 msgstr "Organização criada."
 
-#: organization/views.py:37
+#: organization/views.py:33
 msgid "Organization updated."
 msgstr "Organização atualizada."
+
+#: organization/views.py:40
+msgid "Organization deleted."
+msgstr "Organização removida."
 
 #: speakerfight/settings.py:140
 msgid "English"

--- a/organization/templates/organization/organization_confirm_delete.html
+++ b/organization/templates/organization/organization_confirm_delete.html
@@ -1,1 +1,36 @@
-This is the deletion page
+{% extends "layout.html" %}
+
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block head_title %}{% trans "Delete Organization" %}: "{{ object }}"{% endblock %}
+
+{% block content %}
+<ol class="breadcrumb">
+  <li><a href="{% url 'index_page' %}">{% trans "Home" %}</a></li>
+  <li>{% trans "Organizations" %}</li>
+  <li>{{ object }}</li>
+  <li class="active">{% trans "Remove" %}</li>
+</ol>
+
+<div class="row">
+  <h1>{% trans "Delete" %} "{{ object }}"</h1>
+  <p>{% trans "Are you sure you want to delete this organization?" %}</p>
+  <p>{% trans "After deleting this organization all events will be lost forever." %}</p>
+  <form method="POST">
+    {% csrf_token %}
+    {% buttons %}
+      <button type="submit" class="btn-flat success text-upper">
+        <i class="icon icon-trash"></i>
+        {% trans "Delete" %}
+      </button>
+      <div class="pull-right">
+        <a href="#" class="link text-upper">
+          <i class="icon-calendar"></i>
+          {% trans "organization detail" %}
+        </a>
+      </div>
+    {% endbuttons %}
+  </form>
+</div>
+{% endblock content %}

--- a/organization/templates/organization/organization_confirm_delete.html
+++ b/organization/templates/organization/organization_confirm_delete.html
@@ -1,0 +1,1 @@
+This is the deletion page

--- a/organization/tests/test_functional.py
+++ b/organization/tests/test_functional.py
@@ -61,6 +61,20 @@ class OrganizationTest(TestCase):
             about='Cool company',
             created_by=self.user,
         )
-        url = reverse('delete_organization', kwargs={'slug': 'speakerfight-corp'})
+        url = reverse('delete_organization', kwargs={'slug': organization.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+    def test_delete_organization(self):
+        organization = Organization.objects.create(
+            name='Speakerfight Corp',
+            about='Cool company',
+            created_by=self.user,
+        )
+        url = reverse('delete_organization', kwargs={'slug': organization.slug})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('list_events'))
+
+        with self.assertRaises(Organization.DoesNotExist):
+            Organization.objects.get(slug=organization.slug)

--- a/organization/tests/test_functional.py
+++ b/organization/tests/test_functional.py
@@ -14,7 +14,7 @@ class OrganizationTest(TestCase):
         self.client = Client()
         self.client.login(username='user', password='user')
 
-    def test_create_event(self):
+    def test_create_organization(self):
         url = reverse('create_organization')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -33,7 +33,7 @@ class OrganizationTest(TestCase):
         self.assertEqual(organization.about, 'Cool company')
         self.assertEqual(organization.created_by, self.user)
 
-    def test_update_event(self):
+    def test_update_organization(self):
         organization = Organization.objects.create(
             name='Speakerfight Corp',
             about='Cool company',
@@ -54,3 +54,13 @@ class OrganizationTest(TestCase):
         organization = Organization.objects.get(slug='speakerfight-school')
         self.assertEqual(organization.name, 'Speakerfight School')
         self.assertEqual(organization.about, 'Cool school')
+
+    def test_delete_organization_confirmation(self):
+        organization = Organization.objects.create(
+            name='Speakerfight Corp',
+            about='Cool company',
+            created_by=self.user,
+        )
+        url = reverse('delete_organization', kwargs={'slug': 'speakerfight-corp'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/organization/urls.py
+++ b/organization/urls.py
@@ -10,4 +10,7 @@ urlpatterns = (
     url(regex=r'/<slug:slug>/update/',
         view=views.UpdateOrganization.as_view(),
         name='update_organization'),
+    url(regex=r'/<slug:slug>/delete/',
+        view=views.DeleteOrganization.as_view(),
+        name='delete_organization'),
 )

--- a/organization/views.py
+++ b/organization/views.py
@@ -35,3 +35,10 @@ class UpdateOrganization(BaseOrganizationView, UpdateView):
 
 class DeleteOrganization(BaseOrganizationView, DeleteView):
     template_Name = 'organization/organization_confirm_delete.html'
+
+    def form_valid(self, form):
+        return self.success_redirect(_(u'Organization deleted.'))
+
+    def get_success_url(self):
+        # TODO: Redirect to the organization list route when it gets done
+        return reverse('list_events')

--- a/organization/views.py
+++ b/organization/views.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.core.urlresolvers import reverse
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
-from django.views.generic.edit import CreateView, UpdateView
+from django.views.generic.edit import CreateView, UpdateView, DeleteView
 
 from . models import Organization
 from core.mixins import LoginRequiredMixin, FormValidRedirectMixing
@@ -31,3 +31,7 @@ class UpdateOrganization(BaseOrganizationView, UpdateView):
     def form_valid(self, form):
         self.object = form.save()
         return self.success_redirect(_(u'Organization updated.'))
+
+
+class DeleteOrganization(BaseOrganizationView, DeleteView):
+    template_Name = 'organization/organization_confirm_delete.html'


### PR DESCRIPTION
This PR enables the URL to remove organizations #287. 

I believe that this feature needs to wait for the `Add Users to Organizations` #285 to let only organization members to remove it. Or maybe only it's owner? What do you have in mind? Im willing to help with the issue #285 too so, let me know if you have any questions.