### PR TITLE
#304 - create a date for start accepting proposals

### DIFF
--- a/deck/models.py
+++ b/deck/models.py
@@ -285,7 +285,7 @@ class Event(DeckBaseModel):
     anonymous_voting = models.BooleanField(
         _('Anonymous Voting?'), default=False)
 
-    accept_proposals_at = models.DateTimeField(null=False, blank=False)
+    accept_proposals_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         ordering = ['-due_date', '-created_at']

--- a/deck/models.py
+++ b/deck/models.py
@@ -285,6 +285,8 @@ class Event(DeckBaseModel):
     anonymous_voting = models.BooleanField(
         _('Anonymous Voting?'), default=False)
 
+    accept_proposals_at = models.DateTimeField(null=False, blank=False)
+
     class Meta:
         ordering = ['-due_date', '-created_at']
         verbose_name = _('Event')

--- a/deck/tests/test_unit.py
+++ b/deck/tests/test_unit.py
@@ -125,6 +125,9 @@ class EventModelIntegrityTest(TestCase):
     def test_assert_event_jury_should_have_a_related_name(self):
         self.assertEquals('event', self.fields['jury'].rel.related_name)
 
+    def test_assert_event_date_accept_proposals_should_not_be_required(self):
+        self.assertEquals(True, self.fields['accept_proposals_at'].null)
+        self.assertEquals(True, self.fields['accept_proposals_at'].blank)
 
 class EventObjectTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
fix a bug from the issue #304.
I added a accept_proposals_at datetimefields to models.py
i added a test for (not required)  accept_proposals_at field