### PR TITLE
Add Sentry User Feedback

### DIFF
--- a/core/templates/500.html
+++ b/core/templates/500.html
@@ -1,5 +1,6 @@
 {% extends "public_layout.html" %}
 {% load i18n %}
+{% load raven %}
 
 {% block head_title %}{% trans "Internal Server Error" %}{% endblock head_title %}
 
@@ -9,7 +10,24 @@
     <div class="col-md-8">
       <h1>{% trans "Internal Server Error" %}</h1>
       <h3>{% trans "I'm sorry, that page is currently unavailable due to a server misconfiguration. The server administrator has been notified, and we apologise for any inconvenience." %}</h3>
+      <div class="row">
+        <div class="col-md-3 col-md-offset-5">
+          <button id="#report-sentry" class="btn-flat info text-center">Report Bug</button>
+        </div>
+      </div>
     </div>
     <div class="col-md-2"></div>
   </div>
+
+<script src="https://cdn.ravenjs.com/3.18.1/raven.min.js" crossorigin="anonymous"></script>
+<script>Raven.config('{% sentry_public_dsn %}').install()</script>
+{% if request.sentry.id %}
+  <script>
+    document.getElementById('#report-sentry').addEventListener('click', showReportDialog, false);
+
+    function showReportDialog() {
+      Raven.showReportDialog({eventId: '{{ request.sentry.id }}'});
+    };
+  </script>
+{% endif %}
 {% endblock content %}

--- a/speakerfight/urls.py
+++ b/speakerfight/urls.py
@@ -3,6 +3,8 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import static
 
+from vanilla import TemplateView
+
 
 urlpatterns = (
     url(r'^admin/', admin.site.urls),
@@ -27,3 +29,5 @@ if settings.DEBUG:
         urlpatterns += (
             url(r'^__debug__/', include(debug_toolbar.urls)),
         )
+
+handler500 = TemplateView.as_view(template_name='500.html')


### PR DESCRIPTION
Issue: #282 

Added button on 500 page that shows Sentry popup for error report/feedback.

I create a custom view to handle on 500 responses because django doesn't include the Sentry id on the default one.

On testing/deploying, please review the Allowed Domains in the Sentry Project Settings page.

Screenshots:

![fireshot capture 3 - speakerfight - internal server error - http___localhost_8000_](https://user-images.githubusercontent.com/1657123/31469861-d844c508-aeb9-11e7-8ffe-266bcaa59f48.png)
![fireshot capture 5 - speakerfight - internal server error - http___localhost_8000_](https://user-images.githubusercontent.com/1657123/31469860-d82110fe-aeb9-11e7-89cc-e1f17380b360.png)
