### PR TITLE
Separate activity forms

### DIFF
--- a/core/static/js/event-schedule.js
+++ b/core/static/js/event-schedule.js
@@ -128,6 +128,51 @@ $(function () {
     $(modal).modal();
   });
 
+  $('.proposal-container').delegate('.update-proposal', 'click', function(e) {
+    e.preventDefault();
+    var modal = $('#update-proposal-modal');
+    $.ajax({
+      url: $(this).parents('.panel').attr('data-href'),
+      method: 'GET',
+    }).success(function(data, status, xhr) {
+      $(modal).find('#id_start_timetable').val(data.start_timetable);
+      $(modal).find('#id_end_timetable').val(data.end_timetable);
+    });
+
+    $(modal).attr('data-href', $(this).parents('.panel').attr('data-href'));
+    $(modal).modal();
+  });
+
+  $('#update-proposal-form').submit(function (e) {
+    e.preventDefault();
+    var modal = $('#update-proposal-modal');
+
+    $.ajax({
+      url: $(modal).attr('data-href'),
+      method: 'PATCH',
+      headers: {
+        'X-CSRFToken': getCookie('csrftoken')
+      },
+      data: {
+        start_timetable: $(modal).find('#id_start_timetable').val(),
+        end_timetable: $(modal).find('#id_end_timetable').val(),
+      }
+    }).success(function(data, status, xhr) {
+
+      var activityBlock = $('#' + data.slug);
+      $(activityBlock).find('.proposal-timetable .timetable').text(data.timetable);
+      $(activityBlock).find('.proposal-timetable').removeClass('hide');
+      $(modal).modal('hide');
+    }).error(function(data, status, xhr) {
+      if (data.status == 403) {
+        alert(data.responseJSON.detail)
+      };
+      for (field in data.responseJSON){
+        $('[name="' + field + '"]').parents('.form-group').addClass('has-error');
+      }
+    });
+  });
+
   $('#update-activity-form').submit(function (e) {
     e.preventDefault();
     var modal = $('#update-activity-modal');

--- a/deck/forms.py
+++ b/deck/forms.py
@@ -97,11 +97,9 @@ class ActivityTimetableForm(forms.ModelForm):
     class Meta:
         model = Activity
         fields = [
-            'title', 'start_timetable', 'end_timetable',
-            'description'
+            'start_timetable', 'end_timetable',
         ]
         widgets = {
-            'title': forms.TextInput(attrs={'class': 'inline-input'}),
             'start_timetable': CustomTimeInputWidget(format='%H:%M'),
             'end_timetable': CustomTimeInputWidget(format='%H:%M'),
         }

--- a/deck/templates/event/event_create_schedule.html
+++ b/deck/templates/event/event_create_schedule.html
@@ -191,7 +191,11 @@
             <h4 class="modal-title">{% trans "Add activity" %}</h4>
           </div>
           <div class="modal-body">
-            {% bootstrap_form activity_form layout='inline' %}
+            {% bootstrap_field activity_form.title layout='inline' %}
+            {% bootstrap_field activity_form.activity_type layout='inline' %}
+            {% bootstrap_field activity_form.description layout='inline' %}
+            {% bootstrap_field activity_form.start_timetable layout='inline' %}
+            {% bootstrap_field activity_form.end_timetable layout='inline' %}
           </div>
           <div class="modal-footer">
             <button type="submit" class="btn-flat success text-upper">
@@ -212,10 +216,40 @@
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
               <span aria-hidden="true">&times;</span>
             </button>
-            <h4 class="modal-title">{% trans "Update timetable" %}</h4>
+            <h4 class="modal-title">{% trans "Update activity" %}</h4>
           </div>
           <div class="modal-body">
-            {% bootstrap_form activity_timetable_form layout='inline' %}
+            {% bootstrap_field activity_form.title layout='inline' %}
+            {% bootstrap_field activity_form.activity_type layout='inline' %}
+            {% bootstrap_field activity_form.description layout='inline' %}
+            {% bootstrap_field activity_form.start_timetable layout='inline' %}
+            {% bootstrap_field activity_form.end_timetable layout='inline' %}
+            <input type="hidden" id="oldSlug">
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn-flat success text-upper">
+              <i class="icon icon-pencil"></i>
+              {% trans "submit" %}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="update-proposal-modal" data-href="">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="update-proposal-form">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h4 class="modal-title">{% trans "Update proposal" %}</h4>
+          </div>
+          <div class="modal-body">
+            {% bootstrap_field activity_timetable_form.start_timetable layout='inline' %}
+            {% bootstrap_field activity_timetable_form.end_timetable layout='inline' %}
             <input type="hidden" id="oldSlug">
           </div>
           <div class="modal-footer">

--- a/deck/templates/event/event_create_schedule.html
+++ b/deck/templates/event/event_create_schedule.html
@@ -72,7 +72,7 @@
                                   <span>{% trans "Disapprove" %}</span>
                                 </a>
                           {% endif %}
-                        <button type="button" class="btn-flat gray text-upper update-activity">
+                        <button type="button" class="btn-flat gray text-upper update-proposal">
                           <i class="icon-pencil"></i>
                         </button>
                         <img src="{{ activity.proposal.author|get_user_photo }}" alt="author photo" class="img-circle author-photo">

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-16 15:48-0200\n"
+"POT-Creation-Date: 2017-10-17 18:19-0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,19 +24,19 @@ msgstr ""
 msgid "You are not allowed to see this page."
 msgstr ""
 
-#: core/forms.py:13
+#: core/forms.py:14
 msgid "Username"
 msgstr ""
 
-#: core/forms.py:14 organization/models.py:16
+#: core/forms.py:15 organization/models.py:16
 msgid "Name"
 msgstr ""
 
-#: core/forms.py:15
+#: core/forms.py:16
 msgid "Email"
 msgstr ""
 
-#: core/forms.py:38
+#: core/forms.py:39
 #, python-format
 msgid "The \"%s\" username are already being used by someone."
 msgstr ""
@@ -545,8 +545,9 @@ msgstr ""
 #: core/templates/account/profile.html:187
 #: core/templates/account/profile.html:223
 #: deck/templates/event/event_create_schedule.html:42
-#: deck/templates/event/event_create_schedule.html:199
-#: deck/templates/event/event_create_schedule.html:223
+#: deck/templates/event/event_create_schedule.html:203
+#: deck/templates/event/event_create_schedule.html:232
+#: deck/templates/event/event_create_schedule.html:258
 #: deck/templates/event/event_form.html:59
 #: deck/templates/proposal/proposal_form.html:78
 #: organization/templates/organization/organization_form.html:59
@@ -1215,15 +1216,19 @@ msgstr ""
 msgid "Add activity"
 msgstr ""
 
-#: deck/templates/event/event_create_schedule.html:215
-msgid "Update timetable"
+#: deck/templates/event/event_create_schedule.html:219
+msgid "Update activity"
 msgstr ""
 
-#: deck/templates/event/event_create_schedule.html:238
+#: deck/templates/event/event_create_schedule.html:248
+msgid "Update proposal"
+msgstr ""
+
+#: deck/templates/event/event_create_schedule.html:273
 msgid "Copy and Paste on your site"
 msgstr ""
 
-#: deck/templates/event/event_create_schedule.html:249
+#: deck/templates/event/event_create_schedule.html:284
 msgid "Raw API"
 msgstr ""
 
@@ -1360,12 +1365,12 @@ msgstr ""
 
 #: deck/templates/event/snippets/event_list_item.html:20
 #: deck/templates/proposal/my_proposals.html:29
-msgid "Due date pasted since the day"
+msgid "Proposals closed in"
 msgstr ""
 
 #: deck/templates/event/snippets/event_list_item.html:23
 #: deck/templates/proposal/my_proposals.html:32
-msgid "Due date in"
+msgid "Accepting proposals until"
 msgstr ""
 
 #: deck/templates/event/snippets/event_list_item.html:30
@@ -1709,11 +1714,11 @@ msgstr ""
 msgid "Organization created."
 msgstr ""
 
-#: organization/views.py:33
+#: organization/views.py:34
 msgid "Organization updated."
 msgstr ""
 
-#: organization/views.py:40
+#: organization/views.py:49
 msgid "Organization deleted."
 msgstr ""
 

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: speakerfight\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-16 15:48-0200\n"
+"POT-Creation-Date: 2017-10-17 18:19-0200\n"
 "PO-Revision-Date: 2017-10-16 14:48-0300\n"
 "Last-Translator: Luan Fonseca de Farias <luanfonceca@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/speakerfight/"
@@ -29,19 +29,19 @@ msgstr ""
 msgid "You are not allowed to see this page."
 msgstr "Você não tem permissão para ver esta página."
 
-#: core/forms.py:13
+#: core/forms.py:14
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: core/forms.py:14 organization/models.py:16
+#: core/forms.py:15 organization/models.py:16
 msgid "Name"
 msgstr "Nome"
 
-#: core/forms.py:15
+#: core/forms.py:16
 msgid "Email"
 msgstr "E-mail"
 
-#: core/forms.py:38
+#: core/forms.py:39
 #, python-format
 msgid "The \"%s\" username are already being used by someone."
 msgstr "O nome de usuário: \"%s\" já está sendo usado por alguém."
@@ -647,8 +647,9 @@ msgstr "cancelar"
 #: core/templates/account/profile.html:187
 #: core/templates/account/profile.html:223
 #: deck/templates/event/event_create_schedule.html:42
-#: deck/templates/event/event_create_schedule.html:199
-#: deck/templates/event/event_create_schedule.html:223
+#: deck/templates/event/event_create_schedule.html:203
+#: deck/templates/event/event_create_schedule.html:232
+#: deck/templates/event/event_create_schedule.html:258
 #: deck/templates/event/event_form.html:59
 #: deck/templates/proposal/proposal_form.html:78
 #: organization/templates/organization/organization_form.html:59
@@ -1383,15 +1384,19 @@ msgstr ""
 msgid "Add activity"
 msgstr "Adicionar atividade"
 
-#: deck/templates/event/event_create_schedule.html:215
-msgid "Update timetable"
-msgstr "Atualizar horário"
+#: deck/templates/event/event_create_schedule.html:219
+msgid "Update activity"
+msgstr "Atualizar atividade"
 
-#: deck/templates/event/event_create_schedule.html:238
+#: deck/templates/event/event_create_schedule.html:248
+msgid "Update proposal"
+msgstr "Atualizar Proposta"
+
+#: deck/templates/event/event_create_schedule.html:273
 msgid "Copy and Paste on your site"
 msgstr "Copie e Cola em seu site"
 
-#: deck/templates/event/event_create_schedule.html:249
+#: deck/templates/event/event_create_schedule.html:284
 msgid "Raw API"
 msgstr "API Pura"
 
@@ -1555,13 +1560,15 @@ msgstr ""
 
 #: deck/templates/event/snippets/event_list_item.html:20
 #: deck/templates/proposal/my_proposals.html:29
-msgid "Due date pasted since the day"
-msgstr "Data limite ultrapassada desde o dia"
+#, fuzzy
+#| msgid "Proposal deleted."
+msgid "Proposals closed in"
+msgstr "Proposta removida."
 
 #: deck/templates/event/snippets/event_list_item.html:23
 #: deck/templates/proposal/my_proposals.html:32
-msgid "Due date in"
-msgstr "Data limite em"
+msgid "Accepting proposals until"
+msgstr ""
 
 #: deck/templates/event/snippets/event_list_item.html:30
 #, python-format
@@ -1961,11 +1968,11 @@ msgstr "Nova Organização"
 msgid "Organization created."
 msgstr "Organização criada."
 
-#: organization/views.py:33
+#: organization/views.py:34
 msgid "Organization updated."
 msgstr "Organização atualizada."
 
-#: organization/views.py:40
+#: organization/views.py:49
 msgid "Organization deleted."
 msgstr "Organização removida."
 
@@ -1976,6 +1983,15 @@ msgstr "Inglês"
 #: speakerfight/settings.py:141
 msgid "Portuguese"
 msgstr "Português"
+
+#~ msgid "Update timetable"
+#~ msgstr "Atualizar horário"
+
+#~ msgid "Due date pasted since the day"
+#~ msgstr "Data limite ultrapassada desde o dia"
+
+#~ msgid "Due date in"
+#~ msgstr "Data limite em"
 
 #~ msgid "Proposal already Rated by you."
 #~ msgstr "Proposta anteriormente votada por Você."


### PR DESCRIPTION
We had the need to separate the form that edits activities and proposal (which is a activity as well) because we don't want to let the user modify proposals.