### PR TITLE
Fix unable to update activity_type

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -26,6 +26,7 @@ class ActivitySerializer(serializers.HyperlinkedModelSerializer):
     author = UserSerializer(read_only=True)
     timetable = serializers.SerializerMethodField()
     url_api_event_activity = serializers.SerializerMethodField()
+    activity_type_display = serializers.SerializerMethodField()
 
     class Meta:
         model = Activity
@@ -33,11 +34,14 @@ class ActivitySerializer(serializers.HyperlinkedModelSerializer):
             'title', 'slug', 'description', 'timetable',
             'activity_type', 'author',
             'start_timetable', 'end_timetable',
-            'url_api_event_activity',
+            'url_api_event_activity', 'activity_type_display',
         )
 
     def get_timetable(self, activity):
         return activity.timetable
+
+    def get_activity_type_display(self, activity):
+        return activity.get_activity_type_display()
 
     def get_url_api_event_activity(self, activity):
         event = activity.track.event

--- a/core/static/js/event-schedule.js
+++ b/core/static/js/event-schedule.js
@@ -118,6 +118,7 @@ $(function () {
     }).success(function(data, status, xhr) {
       $(modal).find('#id_title').val(data.title);
       $(modal).find('#id_description').val(data.description);
+      $(modal).find('#id_activity_type').val(data.activity_type);
       tinymce.get('id_description').setContent(data.description);
       $(modal).find('#id_start_timetable').val(data.start_timetable);
       $(modal).find('#id_end_timetable').val(data.end_timetable);
@@ -185,6 +186,7 @@ $(function () {
       },
       data: {
         title: $(modal).find('#id_title').val(),
+        activity_type: $(modal).find('#id_activity_type').val(),
         description: $(modal).find('#id_description').val(),
         start_timetable: $(modal).find('#id_start_timetable').val(),
         end_timetable: $(modal).find('#id_end_timetable').val(),
@@ -200,6 +202,7 @@ $(function () {
       var activityBlock = $('#' + data.slug);
       $(activityBlock).find('.proposal-points').addClass('hide');
       $(activityBlock).find('.proposal-timetable .timetable').text(data.timetable);
+      $(activityBlock).find('.activity-type').text(data.activity_type_display);
       $(activityBlock).find('.proposal-title a').text(data.title);
       $(activityBlock).find('.proposal-timetable').removeClass('hide');
       $(modal).modal('hide');

--- a/deck/templates/event/event_create_schedule.html
+++ b/deck/templates/event/event_create_schedule.html
@@ -115,7 +115,7 @@
                       </div>
                       <div class="pull-left text-center proposal-rate">
                         <div class="proposal-timetable">
-                          <p>{{ activity.get_activity_type_display }}</p>
+                          <p class="activity-type">{{ activity.get_activity_type_display }}</p>
                           <span class="timetable">{{ activity.timetable }}</span>
                         </div>
                       </div>


### PR DESCRIPTION
Fixes
- include activity_type to our payload in updating the schedule.
- Add class to our HTML element to render the updated activity_type after the update.
- include activity_type_display in our serializer to have a more presentable activity_type text.

This will fix #343