### PR TITLE
feat(deck): restrict proposal creation before accept_proposals_at date

### DIFF
--- a/deck/migrations/0020_add_accept_proposals_at.py
+++ b/deck/migrations/0020_add_accept_proposals_at.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('deck', '0019_merge_20171017_1449'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='accept_proposals_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/deck/models.py
+++ b/deck/models.py
@@ -210,6 +210,9 @@ class Proposal(Activity):
         if not self.pk and self.event.closing_date_is_passed:
             raise ValidationError(
                 _("This Event doesn't accept Proposals anymore."))
+        if not self.pk and self.event.accept_proposals_at_not_reached:
+            raise ValidationError(
+                _("This Event doesn't accept Proposals yet."))
         return super(Proposal, self).save(*args, **kwargs)
 
     @property
@@ -315,6 +318,10 @@ class Track(models.Model):
 class Event(DeckBaseModel):
     allow_public_voting = models.BooleanField(_('Allow Public Voting'),
                                               default=True)
+    accept_proposals_at = models.DateTimeField(
+        null=True,
+        blank=True
+    )
     closing_date = models.DateTimeField(null=False, blank=False)
     slots = models.SmallIntegerField(_('Slots'), default=10)
 
@@ -332,6 +339,11 @@ class Event(DeckBaseModel):
     @property
     def closing_date_is_passed(self):
         return timezone.now() > self.closing_date
+    @property
+    def accept_proposals_at_not_reached(self):
+        if not self.accept_proposals_at:
+            return False
+        return timezone.now() < self.accept_proposals_at
 
     @property
     def closing_date_is_close(self):

--- a/deck/tests/test_functional.py
+++ b/deck/tests/test_functional.py
@@ -391,6 +391,22 @@ class EventTest(TestCase):
             reverse('create_event_proposal', kwargs={'slug': event.slug}))
         self.assertEqual(302, response.status_code)
 
+    def test_event_create_event_proposal_before_accept_proposals_at(self):
+        event_data = self.event_data.copy()
+        event_data.update(accept_proposals_at=now() + timedelta(hours=24))
+        event = Event.objects.create(**event_data)
+        response = self.client.post(
+            reverse('create_event_proposal', kwargs={'slug': event.slug}),
+            self.proposal_data, follow=True
+        )
+        message = _(u"This Event doesn't accept Proposals yet.")
+        self.assertIn(six.text_type(message), response.content.decode('utf-8'))
+        self.assertEquals(0, event.proposals.count())
+
+        response = self.client.get(
+            reverse('create_event_proposal', kwargs={'slug': event.slug}))
+        self.assertEqual(302, response.status_code)
+
     def test_export_votes_to_csv_queryset(self):
         event = Event.objects.create(**self.event_data)
         proposal = Proposal.objects.create(event=event, **self.proposal_data)

--- a/deck/tests/test_models.py
+++ b/deck/tests/test_models.py
@@ -42,6 +42,19 @@ class EventModelTests(TestCase):
         self.event.jury.users.add(user)
         self.assertTrue(self.event.user_in_jury(user))
 
+    def test_accept_proposals_at_not_reached_is_false_when_field_is_empty(self):
+        self.assertFalse(self.event.accept_proposals_at_not_reached)
+
+    def test_accept_proposals_at_not_reached_is_true_before_the_date(self):
+        self.event.accept_proposals_at = timezone.now() + timedelta(days=1)
+        self.event.save()
+        self.assertTrue(self.event.accept_proposals_at_not_reached)
+
+    def test_accept_proposals_at_not_reached_is_false_after_the_date(self):
+        self.event.accept_proposals_at = timezone.now() - timedelta(days=1)
+        self.event.save()
+        self.assertFalse(self.event.accept_proposals_at_not_reached)
+
 
 class TrackModelTests(TestCase):
 

--- a/deck/views.py
+++ b/deck/views.py
@@ -263,6 +263,13 @@ class CreateProposal(LoginRequiredMixin,
                 self.request,
                 _(u"This Event doesn't accept Proposals anymore."))
             return HttpResponseRedirect(
+            reverse('view_event', kwargs={'slug': event.slug}),
+            )
+        if event.accept_proposals_at_not_reached:
+            messages.error(
+                self.request,
+                _(u"This Event doesn't accept Proposals yet."))
+            return HttpResponseRedirect(
                 reverse('view_event', kwargs={'slug': event.slug}),
             )
         return super(CreateProposal, self).get(request, *args, **kwargs)


### PR DESCRIPTION
## Descrição

Implementa a issue [luanfonceca#306](https://github.com/luanfonceca/speakerfight/issues/306) do Speakerfight, impedindo a criação de propostas antes da data definida em `accept_proposals_at` do `Event`.

Esta issue depende da [luanfonceca#304](https://github.com/luanfonceca/speakerfight/issues/304).

## Alterações realizadas

- Adicionada a property `accept_proposals_at_not_reached` ao modelo `Event`;
- Adicionada checagem no `Proposal.save()` para impedir a criação da proposta antes da data de abertura, seguindo o mesmo padrão já usado para `closing_date_is_passed`;
- Adicionada checagem equivalente na view `CreateProposal.get()`, redirecionando o usuário com mensagem de erro;
- Adicionados testes para verificar:
  * a property `accept_proposals_at_not_reached` (campo vazio, antes da data, depois da data);
  * o comportamento da view ao tentar criar proposta antes da data de abertura.

Closes #306
## Testes

`Ran 214 tests — OK`